### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 documentation = "https://docs.rs/utote"
 
 [dependencies]
-packed_simd = { version = "0.3.4", package = "packed_simd_2", optional = true }
+packed_simd = { version = "0.3.9", optional = true }
 rand = { version = "0.8.3", optional = true }
 num-traits = "0.2.14"
 paste = "1.0.5"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Multiset will eventually be implemented on slice and then used from different
 multiset varieties implmenting deref to slice could cause confusion in the 
 code.
 
-[packed_simd]: https://docs.rs/packed_simd_2
+[packed_simd]: https://docs.rs/packed_simd
 [const_generics]: https://github.com/rust-lang/rust/issues/44580
 [const_evaluatable_checked]: https://github.com/rust-lang/rust/issues/76560
 [std::simd]: https://github.com/rust-lang/stdsimd

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! # Cargo Features
 //!
 //! - __simd__: Requires nightly rust toolchain. Enables simd implementations
-//! using the [__packed_simd__ crate](https://docs.rs/packed_simd_2) crate and
+//! using the [__packed_simd__ crate](https://docs.rs/packed_simd) crate and
 //! unsatble features: [const_generics](https://github.com/rust-lang/rust/issues/44580)
 //! and [const_evaluatable_checked](https://github.com/rust-lang/rust/issues/76560).
 //! - __rand__: Enables [`choose_random`](Multiset::choose_random) methods for


### PR DESCRIPTION
packed_simd is now again being published under its original name.